### PR TITLE
Reduce width of the Navigation Panel

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 #
@@ -26,7 +26,6 @@ description: >- # this means to ignore newlines until "baseurl:"
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
-
 
 # Build settings
 theme: just-the-docs

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,8 @@
     <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
 
     <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
+		
 
     {% if site.ga_tracking != nil %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,5 @@
+@media (min-width: 1064px) {
+	.side-bar {
+		width: 264px;
+	}
+}


### PR DESCRIPTION
Overrides JTD CSS media query for the navigation panel width when screen size above 1064px. 

Solves #11. 